### PR TITLE
fix: add cleanup method for clean the processes

### DIFF
--- a/flood/flood/facade/llm.py
+++ b/flood/flood/facade/llm.py
@@ -2053,3 +2053,20 @@ class LLM:
         vals = list(str(share_value.value))
         vals[index] = str(min(value, 1))
         share_value.value = int("".join(vals))
+
+    def cleanup(self):
+        """Clean up worker processes and release CUDA resources."""
+        if hasattr(self, 'processes') and self.processes:
+            for process in self.processes:
+                if process.is_alive():
+                    process.terminate()
+                    process.join(timeout=2)
+                    if process.is_alive():
+                        process.kill()
+                        process.join()
+            self.processes = []
+        
+
+    def __del__(self):
+        """Destructor to ensure cleanup on object deletion."""
+        self.cleanup()


### PR DESCRIPTION
I found that after running simple_example.py, nvidia-smi still showed that I had processes consuming memory. I suspected that the created processes were not being cleared, so I added code to clean up the processes, which solved the problem.